### PR TITLE
feat: enhance SQL query compilation and record processing logic for b…

### DIFF
--- a/lib/private/machines/private/compile-statement.js
+++ b/lib/private/machines/private/compile-statement.js
@@ -43,12 +43,26 @@ module.exports = function compileStatement(statement) {
     ) {
       const orderClauses = globalOrderBy.map((orderItem) => {
         if (typeof orderItem === 'string') {
+          if (orderItem.includes('.')) {
+            const parts = orderItem.split('.')
+            if (parts.length === 2) {
+              const [tableName, columnName] = parts
+              return `\`${tableName}\`.\`${columnName}\` ASC`
+            }
+          }
           return `\`${orderItem}\` ASC`
         }
         if (typeof orderItem === 'object') {
           const key = Object.keys(orderItem)[0]
           const direction =
             orderItem[key].toUpperCase() === 'DESC' ? 'DESC' : 'ASC'
+          if (key.includes('.')) {
+            const parts = key.split('.')
+            if (parts.length === 2) {
+              const [tableName, columnName] = parts
+              return `\`${tableName}\`.\`${columnName}\` ${direction}`
+            }
+          }
           return `\`${key}\` ${direction}`
         }
         return orderItem
@@ -61,6 +75,18 @@ module.exports = function compileStatement(statement) {
 
   // Handle regular SELECT statements
   if (statement.select) {
+    // Determine parent table for ORDER BY disambiguation
+    let parentTable = null
+    if (statement.from) {
+      if (statement.from.includes(' as ')) {
+        parentTable = statement.from.split(' as ')[0].trim()
+      } else {
+        parentTable = statement.from
+      }
+    }
+    const hasJoins =
+      statement.leftOuterJoin && statement.leftOuterJoin.length > 0
+
     // SELECT clause
     if (Array.isArray(statement.select) && statement.select.length > 0) {
       const selectColumns = statement.select.map((col) => {
@@ -168,12 +194,34 @@ module.exports = function compileStatement(statement) {
     ) {
       const orderClauses = statement.orderBy.map((orderItem) => {
         if (typeof orderItem === 'string') {
+          if (orderItem.includes('.')) {
+            const parts = orderItem.split('.')
+            if (parts.length === 2) {
+              const [tableName, columnName] = parts
+              return `\`${tableName}\`.\`${columnName}\` ASC`
+            }
+          }
+          // If there are JOINs and column is unqualified, prefix with parent table
+          if (hasJoins && parentTable) {
+            return `\`${parentTable}\`.\`${orderItem}\` ASC`
+          }
           return `\`${orderItem}\` ASC`
         }
         if (typeof orderItem === 'object') {
           const key = Object.keys(orderItem)[0]
           const direction =
             orderItem[key].toUpperCase() === 'DESC' ? 'DESC' : 'ASC'
+          if (key.includes('.')) {
+            const parts = key.split('.')
+            if (parts.length === 2) {
+              const [tableName, columnName] = parts
+              return `\`${tableName}\`.\`${columnName}\` ${direction}`
+            }
+          }
+          // If there are JOINs and column is unqualified, prefix with parent table
+          if (hasJoins && parentTable) {
+            return `\`${parentTable}\`.\`${key}\` ${direction}`
+          }
           return `\`${key}\` ${direction}`
         }
         return orderItem

--- a/lib/private/machines/private/process-each-record.js
+++ b/lib/private/machines/private/process-each-record.js
@@ -55,6 +55,11 @@ module.exports = function processEachRecord(options) {
       _.each(WLModel.definition, (attrDef, attrName) => {
         const columnName = attrDef.columnName || attrName
 
+        // Skip processing if this is a populated association (it's already an object/array)
+        if (attrDef.collection || attrDef.model) {
+          return
+        }
+
         if (columnName in record) {
           switch (attrDef.type) {
             case 'boolean':
@@ -66,7 +71,10 @@ module.exports = function processEachRecord(options) {
 
             case 'json':
               // SQLite stores JSON as text, so we need to parse it
-              if (record[columnName] !== null) {
+              if (
+                record[columnName] !== null &&
+                typeof record[columnName] === 'string'
+              ) {
                 try {
                   record[columnName] = JSON.parse(record[columnName])
                 } catch (e) {
@@ -80,7 +88,9 @@ module.exports = function processEachRecord(options) {
 
             case 'number':
               // Ensure numbers are actually numbers
-              record[columnName] = Number(record[columnName])
+              if (typeof record[columnName] !== 'number') {
+                record[columnName] = Number(record[columnName])
+              }
               break
 
             case 'date':


### PR DESCRIPTION
Resolves #7 

This pull request improves SQL query compilation and record processing logic, focusing on better handling of column disambiguation in `ORDER BY` clauses (especially with joins) and more robust data type conversion for records. The changes enhance correctness and prevent errors when dealing with joined tables and various attribute types.

### SQL Query Compilation Improvements

* Improved handling of `ORDER BY` clauses to correctly qualify columns with their table names when the column name includes a dot or when there are joins, preventing ambiguous column references. Unqualified columns are now prefixed with the parent table name if joins are present. (`lib/private/machines/private/compile-statement.js`) [[1]](diffhunk://#diff-1c0a873080664f9c5040d8063599beaedcbc752732dd66bf8bc90e56d6dbb3acR46-R65) [[2]](diffhunk://#diff-1c0a873080664f9c5040d8063599beaedcbc752732dd66bf8bc90e56d6dbb3acR78-R89) [[3]](diffhunk://#diff-1c0a873080664f9c5040d8063599beaedcbc752732dd66bf8bc90e56d6dbb3acR197-R224)

### Record Processing Enhancements

* Skipped type conversion for populated associations (i.e., attributes that are collections or models), ensuring that already populated objects/arrays are not processed again. (`lib/private/machines/private/process-each-record.js`)
* Improved JSON attribute handling by parsing only string values, preventing errors when the value is already an object or null. (`lib/private/machines/private/process-each-record.js`)
* Ensured that number attributes are always converted to numbers, adding a type check before conversion. (`lib/private/machines/private/process-each-record.js`)