### PR TITLE
feat: change default database URL to db/local.db

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ module.exports = {
   // Default configuration for connections
   defaults: {
     schema: false,
-    url: 'db/data.db',
+    url: 'db/local.db',
     pragmas: {
       journal_mode: 'WAL'
     }


### PR DESCRIPTION
Closes #9

This PR changes the default database URL from `db/data.db` to `db/local.db` to better reflect that it's a local development database.